### PR TITLE
Add main files to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,6 +12,9 @@
   ],
   "license": "MIT",
   "private": false,
+  "main": [
+    "dist/angular-trackjs.min.js"
+  ],
   "ignore": [
     "**/.*",
     "node_modules",


### PR DESCRIPTION
This ensures that tools such as grunt-usemin pick up the required files and include them in its managed block.